### PR TITLE
ticket-acquiring function takes tipset identifier

### DIFF
--- a/sealing.go
+++ b/sealing.go
@@ -35,7 +35,6 @@ type SealingAPI interface {
 	SendMsg(ctx context.Context, from, to address.Address, method abi.MethodNum, value, gasPrice big.Int, gasLimit int64, params []byte) (cid.Cid, error)
 	ChainHead(ctx context.Context) (TipSetToken, abi.ChainEpoch, error)
 	ChainGetRandomness(ctx context.Context, tok TipSetToken, personalization crypto.DomainSeparationTag, randEpoch abi.ChainEpoch, entropy []byte) (abi.Randomness, error)
-	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
 }
 
 type Sealing struct {

--- a/states.go
+++ b/states.go
@@ -47,6 +47,12 @@ func (m *Sealing) handlePacking(ctx statemachine.Context, sector SectorInfo) err
 }
 
 func (m *Sealing) handlePreCommit1(ctx statemachine.Context, sector SectorInfo) error {
+	tok, _, err := m.api.ChainHead(ctx.Context())
+	if err != nil {
+		log.Errorf("handlePreCommit1: api error, not proceeding: %+v", err)
+		return nil
+	}
+
 	if err := checkPieces(ctx.Context(), sector, m.api); err != nil { // Sanity check state
 		switch err.(type) {
 		case *ErrApi:
@@ -62,7 +68,7 @@ func (m *Sealing) handlePreCommit1(ctx statemachine.Context, sector SectorInfo) 
 	}
 
 	log.Infow("performing sector replication...", "sector", sector.SectorNumber)
-	ticketValue, ticketEpoch, err := m.tktFn(ctx.Context())
+	ticketValue, ticketEpoch, err := m.tktFn(ctx.Context(), tok)
 	if err != nil {
 		return ctx.Send(SectorSealPreCommitFailed{xerrors.Errorf("getting ticket failed: %w", err)})
 	}

--- a/types.go
+++ b/types.go
@@ -98,7 +98,7 @@ func (t *SectorInfo) existingPieces() []abi.UnpaddedPieceSize {
 	return out
 }
 
-type TicketFn func(context.Context) (abi.SealRandomness, abi.ChainEpoch, error)
+type TicketFn func(ctx context.Context, tok TipSetToken) (abi.SealRandomness, abi.ChainEpoch, error)
 
 type SectorIDCounter interface {
 	Next() (abi.SectorNumber, error)


### PR DESCRIPTION
## Why does this PR exist?

To ensure a consistent view when querying the chain, the FSM should always pass a `TipSetToken` to the node.

## Notes

I will update lotus after this PR merges.