### PR TITLE
initialize FSM with pre-commit expiry policy

### DIFF
--- a/cbor_gen.go
+++ b/cbor_gen.go
@@ -13,7 +13,7 @@ import (
 
 var _ = xerrors.Errorf
 
-func (t *PieceWithOptionalDealInfo) MarshalCBOR(w io.Writer) error {
+func (t *Piece) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -56,7 +56,7 @@ func (t *PieceWithOptionalDealInfo) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *PieceWithOptionalDealInfo) UnmarshalCBOR(r io.Reader) error {
+func (t *Piece) UnmarshalCBOR(r io.Reader) error {
 	br := cbg.GetPeeker(r)
 
 	maj, extra, err := cbg.CborReadHeader(br)
@@ -68,7 +68,7 @@ func (t *PieceWithOptionalDealInfo) UnmarshalCBOR(r io.Reader) error {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("PieceWithOptionalDealInfo: map struct too large (%d)", extra)
+		return fmt.Errorf("Piece: map struct too large (%d)", extra)
 	}
 
 	var name string
@@ -463,26 +463,26 @@ func (t *SectorInfo) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.PiecesWithOptionalDealInfo ([]sealing.PieceWithOptionalDealInfo) (slice)
-	if len("PiecesWithOptionalDealInfo") > cbg.MaxLength {
-		return xerrors.Errorf("Value in field \"PiecesWithOptionalDealInfo\" was too long")
+	// t.Pieces ([]sealing.Piece) (slice)
+	if len("Pieces") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Pieces\" was too long")
 	}
 
-	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajTextString, uint64(len("PiecesWithOptionalDealInfo")))); err != nil {
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajTextString, uint64(len("Pieces")))); err != nil {
 		return err
 	}
-	if _, err := w.Write([]byte("PiecesWithOptionalDealInfo")); err != nil {
+	if _, err := w.Write([]byte("Pieces")); err != nil {
 		return err
 	}
 
-	if len(t.PiecesWithOptionalDealInfo) > cbg.MaxLength {
-		return xerrors.Errorf("Slice value in field t.PiecesWithOptionalDealInfo was too long")
+	if len(t.Pieces) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Pieces was too long")
 	}
 
-	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajArray, uint64(len(t.PiecesWithOptionalDealInfo)))); err != nil {
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajArray, uint64(len(t.Pieces)))); err != nil {
 		return err
 	}
-	for _, v := range t.PiecesWithOptionalDealInfo {
+	for _, v := range t.Pieces {
 		if err := v.MarshalCBOR(w); err != nil {
 			return err
 		}
@@ -897,8 +897,8 @@ func (t *SectorInfo) UnmarshalCBOR(r io.Reader) error {
 
 				t.SectorType = abi.RegisteredProof(extraI)
 			}
-			// t.PiecesWithOptionalDealInfo ([]sealing.PieceWithOptionalDealInfo) (slice)
-		case "PiecesWithOptionalDealInfo":
+			// t.Pieces ([]sealing.Piece) (slice)
+		case "Pieces":
 
 			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
@@ -906,23 +906,23 @@ func (t *SectorInfo) UnmarshalCBOR(r io.Reader) error {
 			}
 
 			if extra > cbg.MaxLength {
-				return fmt.Errorf("t.PiecesWithOptionalDealInfo: array too large (%d)", extra)
+				return fmt.Errorf("t.Pieces: array too large (%d)", extra)
 			}
 
 			if maj != cbg.MajArray {
 				return fmt.Errorf("expected cbor array")
 			}
 			if extra > 0 {
-				t.PiecesWithOptionalDealInfo = make([]PieceWithOptionalDealInfo, extra)
+				t.Pieces = make([]Piece, extra)
 			}
 			for i := 0; i < int(extra); i++ {
 
-				var v PieceWithOptionalDealInfo
+				var v Piece
 				if err := v.UnmarshalCBOR(br); err != nil {
 					return err
 				}
 
-				t.PiecesWithOptionalDealInfo[i] = v
+				t.Pieces[i] = v
 			}
 
 			// t.TicketValue (abi.SealRandomness) (slice)

--- a/checks.go
+++ b/checks.go
@@ -50,15 +50,15 @@ func checkPieces(ctx context.Context, si SectorInfo, api SealingAPI) error {
 		}
 
 		if proposal.PieceCID != pdi.Piece.PieceCID {
-			return &ErrInvalidDeals{xerrors.Errorf("piece %d (or %d) of sector %d refers deal %d with wrong PieceCID: %x != %x", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, pdi.Piece.PieceCID, proposal.PieceCID)}
+			return &ErrInvalidDeals{xerrors.Errorf("piece %d (of %d) of sector %d refers deal %d with wrong PieceCID: %x != %x", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, pdi.Piece.PieceCID, proposal.PieceCID)}
 		}
 
 		if pdi.Piece.Size != proposal.PieceSize {
-			return &ErrInvalidDeals{xerrors.Errorf("piece %d (or %d) of sector %d refers deal %d with different size: %d != %d", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, pdi.Piece.Size, proposal.PieceSize)}
+			return &ErrInvalidDeals{xerrors.Errorf("piece %d (of %d) of sector %d refers deal %d with different size: %d != %d", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, pdi.Piece.Size, proposal.PieceSize)}
 		}
 
 		if height >= proposal.StartEpoch {
-			return &ErrExpiredDeals{xerrors.Errorf("piece %d (or %d) of sector %d refers expired deal %d - should start at %d, head %d", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, proposal.StartEpoch, height)}
+			return &ErrExpiredDeals{xerrors.Errorf("piece %d (of %d) of sector %d refers expired deal %d - should start at %d, head %d", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, proposal.StartEpoch, height)}
 		}
 	}
 

--- a/checks.go
+++ b/checks.go
@@ -33,7 +33,7 @@ func checkPieces(ctx context.Context, si SectorInfo, api SealingAPI) error {
 		return &ErrApi{xerrors.Errorf("getting chain head: %w", err)}
 	}
 
-	for i, pdi := range si.PiecesWithOptionalDealInfo {
+	for i, pdi := range si.Pieces {
 		// if no deal is associated with the piece, ensure that we added it as
 		// filler (i.e. ensure that it has a zero PieceCID)
 		if pdi.DealInfo == nil {
@@ -50,15 +50,15 @@ func checkPieces(ctx context.Context, si SectorInfo, api SealingAPI) error {
 		}
 
 		if proposal.PieceCID != pdi.Piece.PieceCID {
-			return &ErrInvalidDeals{xerrors.Errorf("piece %d (of %d) of sector %d refers deal %d with wrong PieceCID: %x != %x", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, pdi.Piece.PieceCID, proposal.PieceCID)}
+			return &ErrInvalidDeals{xerrors.Errorf("piece %d (of %d) of sector %d refers deal %d with wrong PieceCID: %x != %x", i, len(si.Pieces), si.SectorNumber, pdi.DealInfo.DealID, pdi.Piece.PieceCID, proposal.PieceCID)}
 		}
 
 		if pdi.Piece.Size != proposal.PieceSize {
-			return &ErrInvalidDeals{xerrors.Errorf("piece %d (of %d) of sector %d refers deal %d with different size: %d != %d", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, pdi.Piece.Size, proposal.PieceSize)}
+			return &ErrInvalidDeals{xerrors.Errorf("piece %d (of %d) of sector %d refers deal %d with different size: %d != %d", i, len(si.Pieces), si.SectorNumber, pdi.DealInfo.DealID, pdi.Piece.Size, proposal.PieceSize)}
 		}
 
 		if height >= proposal.StartEpoch {
-			return &ErrExpiredDeals{xerrors.Errorf("piece %d (of %d) of sector %d refers expired deal %d - should start at %d, head %d", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, proposal.StartEpoch, height)}
+			return &ErrExpiredDeals{xerrors.Errorf("piece %d (of %d) of sector %d refers expired deal %d - should start at %d, head %d", i, len(si.Pieces), si.SectorNumber, pdi.DealInfo.DealID, proposal.StartEpoch, height)}
 		}
 	}
 

--- a/checks.go
+++ b/checks.go
@@ -27,40 +27,38 @@ type ErrExpiredTicket struct{ error }
 type ErrBadSeed struct{ error }
 type ErrInvalidProof struct{ error }
 
-// checkPieces validates that:
-//  - Each piece han a corresponding on chain deal
-//  - Piece commitments match with on chain deals
-//  - Piece sizes match
-//  - Deals aren't expired
 func checkPieces(ctx context.Context, si SectorInfo, api SealingAPI) error {
 	tok, height, err := api.ChainHead(ctx)
 	if err != nil {
 		return &ErrApi{xerrors.Errorf("getting chain head: %w", err)}
 	}
 
-	for i, piece := range si.Pieces {
-		if piece.DealID == nil {
-			exp := zerocomm.ZeroPieceCommitment(piece.Size)
-			if piece.CommP != exp {
-				return &ErrInvalidPiece{xerrors.Errorf("deal %d piece %d had non-zero CommP %+v", piece.DealID, i, piece.CommP)}
+	for i, pdi := range si.PiecesWithOptionalDealInfo {
+		// if no deal is associated with the piece, ensure that we added it as
+		// filler (i.e. ensure that it has a zero PieceCID)
+		if pdi.DealInfo == nil {
+			exp := zerocomm.ZeroPieceCommitment(pdi.Piece.Size.Unpadded())
+			if !pdi.Piece.PieceCID.Equals(exp) {
+				return &ErrInvalidPiece{xerrors.Errorf("sector %d piece %d had non-zero PieceCID %+v", si.SectorNumber, i, pdi.Piece.PieceCID)}
 			}
 			continue
 		}
-		proposal, _, err := api.StateMarketStorageDeal(ctx, *piece.DealID, tok)
+
+		proposal, _, err := api.StateMarketStorageDeal(ctx, pdi.DealInfo.DealID, tok)
 		if err != nil {
-			return &ErrApi{xerrors.Errorf("getting deal %d for piece %d: %w", piece.DealID, i, err)}
+			return &ErrApi{xerrors.Errorf("getting deal %d for piece %d: %w", pdi.DealInfo.DealID, i, err)}
 		}
 
-		if proposal.PieceCID != piece.CommP {
-			return &ErrInvalidDeals{xerrors.Errorf("piece %d (or %d) of sector %d refers deal %d with wrong CommP: %x != %x", i, len(si.Pieces), si.SectorNumber, piece.DealID, piece.CommP, proposal.PieceCID)}
+		if proposal.PieceCID != pdi.Piece.PieceCID {
+			return &ErrInvalidDeals{xerrors.Errorf("piece %d (or %d) of sector %d refers deal %d with wrong PieceCID: %x != %x", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, pdi.Piece.PieceCID, proposal.PieceCID)}
 		}
 
-		if piece.Size != proposal.PieceSize.Unpadded() {
-			return &ErrInvalidDeals{xerrors.Errorf("piece %d (or %d) of sector %d refers deal %d with different size: %d != %d", i, len(si.Pieces), si.SectorNumber, piece.DealID, piece.Size, proposal.PieceSize)}
+		if pdi.Piece.Size != proposal.PieceSize {
+			return &ErrInvalidDeals{xerrors.Errorf("piece %d (or %d) of sector %d refers deal %d with different size: %d != %d", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, pdi.Piece.Size, proposal.PieceSize)}
 		}
 
 		if height >= proposal.StartEpoch {
-			return &ErrExpiredDeals{xerrors.Errorf("piece %d (or %d) of sector %d refers expired deal %d - should start at %d, head %d", i, len(si.Pieces), si.SectorNumber, piece.DealID, proposal.StartEpoch, height)}
+			return &ErrExpiredDeals{xerrors.Errorf("piece %d (or %d) of sector %d refers expired deal %d - should start at %d, head %d", i, len(si.PiecesWithOptionalDealInfo), si.SectorNumber, pdi.DealInfo.DealID, proposal.StartEpoch, height)}
 		}
 	}
 
@@ -75,7 +73,7 @@ func checkPrecommit(ctx context.Context, maddr address.Address, si SectorInfo, a
 		return &ErrApi{xerrors.Errorf("getting chain head: %w", err)}
 	}
 
-	commD, err := api.StateComputeDataCommitment(ctx, maddr, si.SectorType, si.deals(), tok)
+	commD, err := api.StateComputeDataCommitment(ctx, maddr, si.SectorType, si.dealIDs(), tok)
 	if err != nil {
 		return &ErrApi{xerrors.Errorf("calling StateComputeDataCommitment: %w", err)}
 	}

--- a/fsm_events.go
+++ b/fsm_events.go
@@ -50,12 +50,12 @@ func (evt SectorForceState) applyGlobal(state *SectorInfo) bool {
 type SectorStart struct {
 	ID         abi.SectorNumber
 	SectorType abi.RegisteredProof
-	Pieces     []PieceWithOptionalDealInfo
+	Pieces     []Piece
 }
 
 func (evt SectorStart) apply(state *SectorInfo) {
 	state.SectorNumber = evt.ID
-	state.PiecesWithOptionalDealInfo = evt.Pieces
+	state.Pieces = evt.Pieces
 	state.SectorType = evt.SectorType
 }
 
@@ -63,7 +63,7 @@ type SectorPacked struct{ FillerPieces []abi.PieceInfo }
 
 func (evt SectorPacked) apply(state *SectorInfo) {
 	for idx := range evt.FillerPieces {
-		state.PiecesWithOptionalDealInfo = append(state.PiecesWithOptionalDealInfo, PieceWithOptionalDealInfo{
+		state.Pieces = append(state.Pieces, Piece{
 			Piece:    evt.FillerPieces[idx],
 			DealInfo: nil, // filler pieces don't have deals associated with them
 		})

--- a/fsm_events.go
+++ b/fsm_events.go
@@ -50,19 +50,24 @@ func (evt SectorForceState) applyGlobal(state *SectorInfo) bool {
 type SectorStart struct {
 	ID         abi.SectorNumber
 	SectorType abi.RegisteredProof
-	Pieces     []Piece
+	Pieces     []PieceWithOptionalDealInfo
 }
 
 func (evt SectorStart) apply(state *SectorInfo) {
 	state.SectorNumber = evt.ID
-	state.Pieces = evt.Pieces
+	state.PiecesWithOptionalDealInfo = evt.Pieces
 	state.SectorType = evt.SectorType
 }
 
-type SectorPacked struct{ Pieces []Piece }
+type SectorPacked struct{ FillerPieces []abi.PieceInfo }
 
 func (evt SectorPacked) apply(state *SectorInfo) {
-	state.Pieces = append(state.Pieces, evt.Pieces...)
+	for idx := range evt.FillerPieces {
+		state.PiecesWithOptionalDealInfo = append(state.PiecesWithOptionalDealInfo, PieceWithOptionalDealInfo{
+			Piece:    evt.FillerPieces[idx],
+			DealInfo: nil, // filler pieces don't have deals associated with them
+		})
+	}
 }
 
 type SectorPackingFailed struct{ error }

--- a/garbage.go
+++ b/garbage.go
@@ -69,9 +69,9 @@ func (m *Sealing) PledgeSector() error {
 			return
 		}
 
-		pdis := make([]PieceWithOptionalDealInfo, len(pieces))
+		pdis := make([]Piece, len(pieces))
 		for idx := range pdis {
-			pdis[idx] = PieceWithOptionalDealInfo{
+			pdis[idx] = Piece{
 				Piece:    pieces[idx],
 				DealInfo: nil,
 			}

--- a/garbage.go
+++ b/garbage.go
@@ -69,15 +69,15 @@ func (m *Sealing) PledgeSector() error {
 			return
 		}
 
-		pdis := make([]Piece, len(pieces))
-		for idx := range pdis {
-			pdis[idx] = Piece{
+		ps := make([]Piece, len(pieces))
+		for idx := range ps {
+			ps[idx] = Piece{
 				Piece:    pieces[idx],
 				DealInfo: nil,
 			}
 		}
 
-		if err := m.newSector(sid, rt, pdis); err != nil {
+		if err := m.newSector(sid, rt, ps); err != nil {
 			log.Errorf("%+v", err)
 			return
 		}

--- a/garbage.go
+++ b/garbage.go
@@ -32,10 +32,7 @@ func (m *Sealing) pledgeSector(ctx context.Context, sectorID abi.SectorID, exist
 
 		existingPieceSizes = append(existingPieceSizes, size)
 
-		out[i] = abi.PieceInfo{
-			Size:     ppi.Size,
-			PieceCID: ppi.PieceCID,
-		}
+		out[i] = ppi
 	}
 
 	return out, nil

--- a/garbage.go
+++ b/garbage.go
@@ -16,14 +16,14 @@ func (m *Sealing) pledgeReader(size abi.UnpaddedPieceSize) io.Reader {
 	return io.LimitReader(&nr.Reader{}, int64(size))
 }
 
-func (m *Sealing) pledgeSector(ctx context.Context, sectorID abi.SectorID, existingPieceSizes []abi.UnpaddedPieceSize, sizes ...abi.UnpaddedPieceSize) ([]Piece, error) {
+func (m *Sealing) pledgeSector(ctx context.Context, sectorID abi.SectorID, existingPieceSizes []abi.UnpaddedPieceSize, sizes ...abi.UnpaddedPieceSize) ([]abi.PieceInfo, error) {
 	if len(sizes) == 0 {
 		return nil, nil
 	}
 
 	log.Infof("Pledge %d, contains %+v", sectorID, existingPieceSizes)
 
-	out := make([]Piece, len(sizes))
+	out := make([]abi.PieceInfo, len(sizes))
 	for i, size := range sizes {
 		ppi, err := m.sealer.AddPiece(ctx, sectorID, existingPieceSizes, size, m.pledgeReader(size))
 		if err != nil {
@@ -32,9 +32,9 @@ func (m *Sealing) pledgeSector(ctx context.Context, sectorID abi.SectorID, exist
 
 		existingPieceSizes = append(existingPieceSizes, size)
 
-		out[i] = Piece{
-			Size:  ppi.Size.Unpadded(),
-			CommP: ppi.PieceCID,
+		out[i] = abi.PieceInfo{
+			Size:     ppi.Size,
+			PieceCID: ppi.PieceCID,
 		}
 	}
 
@@ -72,7 +72,15 @@ func (m *Sealing) PledgeSector() error {
 			return
 		}
 
-		if err := m.newSector(sid, rt, pieces); err != nil {
+		pdis := make([]PieceWithOptionalDealInfo, len(pieces))
+		for idx := range pdis {
+			pdis[idx] = PieceWithOptionalDealInfo{
+				Piece:    pieces[idx],
+				DealInfo: nil,
+			}
+		}
+
+		if err := m.newSector(sid, rt, pdis); err != nil {
 			log.Errorf("%+v", err)
 			return
 		}

--- a/gen/main.go
+++ b/gen/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	err := gen.WriteMapEncodersToFile("./cbor_gen.go", "sealing",
-		sealing.PieceWithOptionalDealInfo{},
+		sealing.Piece{},
 		sealing.DealInfo{},
 		sealing.DealSchedule{},
 		sealing.SectorInfo{},

--- a/gen/main.go
+++ b/gen/main.go
@@ -11,7 +11,9 @@ import (
 
 func main() {
 	err := gen.WriteMapEncodersToFile("./cbor_gen.go", "sealing",
-		sealing.Piece{},
+		sealing.PieceWithOptionalDealInfo{},
+		sealing.DealInfo{},
+		sealing.DealSchedule{},
 		sealing.SectorInfo{},
 		sealing.Log{},
 	)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2
+	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663 // indirect
 	github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9

--- a/precommit_policy.go
+++ b/precommit_policy.go
@@ -7,7 +7,7 @@ import (
 )
 
 type PreCommitPolicy interface {
-	Expiration(ctx context.Context, pdis ...PieceWithOptionalDealInfo) (abi.ChainEpoch, error)
+	Expiration(ctx context.Context, pdis ...Piece) (abi.ChainEpoch, error)
 }
 
 type Chain interface {
@@ -44,7 +44,7 @@ func NewBasicPreCommitPolicy(api Chain, duration abi.ChainEpoch) BasicPreCommitP
 
 // Expiration produces the pre-commit sector expiration epoch for an encoded
 // replica containing the provided enumeration of pieces and deals.
-func (p *BasicPreCommitPolicy) Expiration(ctx context.Context, pdis ...PieceWithOptionalDealInfo) (abi.ChainEpoch, error) {
+func (p *BasicPreCommitPolicy) Expiration(ctx context.Context, pdis ...Piece) (abi.ChainEpoch, error) {
 	_, epoch, err := p.api.ChainHead(ctx)
 	if err != nil {
 		return 0, nil

--- a/precommit_policy.go
+++ b/precommit_policy.go
@@ -7,7 +7,7 @@ import (
 )
 
 type PreCommitPolicy interface {
-	Expiration(ctx context.Context, pdis ...Piece) (abi.ChainEpoch, error)
+	Expiration(ctx context.Context, ps ...Piece) (abi.ChainEpoch, error)
 }
 
 type Chain interface {
@@ -44,7 +44,7 @@ func NewBasicPreCommitPolicy(api Chain, duration abi.ChainEpoch) BasicPreCommitP
 
 // Expiration produces the pre-commit sector expiration epoch for an encoded
 // replica containing the provided enumeration of pieces and deals.
-func (p *BasicPreCommitPolicy) Expiration(ctx context.Context, pdis ...Piece) (abi.ChainEpoch, error) {
+func (p *BasicPreCommitPolicy) Expiration(ctx context.Context, ps ...Piece) (abi.ChainEpoch, error) {
 	_, epoch, err := p.api.ChainHead(ctx)
 	if err != nil {
 		return 0, nil
@@ -52,7 +52,7 @@ func (p *BasicPreCommitPolicy) Expiration(ctx context.Context, pdis ...Piece) (a
 
 	var end *abi.ChainEpoch
 
-	for _, p := range pdis {
+	for _, p := range ps {
 		if p.DealInfo == nil {
 			continue
 		}

--- a/precommit_policy.go
+++ b/precommit_policy.go
@@ -1,0 +1,76 @@
+package sealing
+
+import (
+	"context"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+)
+
+type PreCommitPolicy interface {
+	Expiration(ctx context.Context, pdis ...PieceWithOptionalDealInfo) (abi.ChainEpoch, error)
+}
+
+type Chain interface {
+	ChainHead(ctx context.Context) (TipSetToken, abi.ChainEpoch, error)
+}
+
+// BasicPreCommitPolicy satisfies PreCommitPolicy. It has two modes:
+//
+// Mode 1: The sector contains a non-zero quantity of pieces with deal info
+// Mode 2: The sector contains no pieces with deal info
+//
+// The BasicPreCommitPolicy#Expiration method is given a slice of the pieces
+// which the miner has encoded into the sector, and from that slice picks either
+// the first or second mode.
+//
+// If we're in Mode 1: The pre-commit expiration epoch will be the maximum
+// deal end epoch of a piece in the sector.
+//
+// If we're in Mode 2: The pre-commit expiration epoch will be set to the
+// current epoch + the provided default duration.
+type BasicPreCommitPolicy struct {
+	api Chain
+
+	duration abi.ChainEpoch
+}
+
+// NewBasicPreCommitPolicy produces a BasicPreCommitPolicy
+func NewBasicPreCommitPolicy(api Chain, duration abi.ChainEpoch) BasicPreCommitPolicy {
+	return BasicPreCommitPolicy{
+		api:      api,
+		duration: duration,
+	}
+}
+
+// Expiration produces the pre-commit sector expiration epoch for an encoded
+// replica containing the provided enumeration of pieces and deals.
+func (p *BasicPreCommitPolicy) Expiration(ctx context.Context, pdis ...PieceWithOptionalDealInfo) (abi.ChainEpoch, error) {
+	_, epoch, err := p.api.ChainHead(ctx)
+	if err != nil {
+		return 0, nil
+	}
+
+	var end *abi.ChainEpoch
+
+	for _, p := range pdis {
+		if p.DealInfo == nil {
+			continue
+		}
+
+		if p.DealInfo.DealSchedule.EndEpoch < epoch {
+			log.Warnf("piece schedule %+v ended before current epoch %d", p, epoch)
+			continue
+		}
+
+		if end == nil || *end < p.DealInfo.DealSchedule.EndEpoch {
+			end = &p.DealInfo.DealSchedule.EndEpoch
+		}
+	}
+
+	if end == nil {
+		tmp := epoch + p.duration
+		end = &tmp
+	}
+
+	return *end, nil
+}

--- a/precommit_policy_test.go
+++ b/precommit_policy_test.go
@@ -1,0 +1,134 @@
+package sealing_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+
+	sealing "github.com/filecoin-project/storage-fsm"
+)
+
+type fakeChain struct {
+	h abi.ChainEpoch
+}
+
+func (f *fakeChain) ChainHead(ctx context.Context) (sealing.TipSetToken, abi.ChainEpoch, error) {
+	return []byte{1, 2, 3}, f.h, nil
+}
+
+func TestBasicPolicyEmptySector(t *testing.T) {
+	policy := sealing.NewBasicPreCommitPolicy(&fakeChain{
+		h: abi.ChainEpoch(55),
+	}, 10)
+
+	exp, err := policy.Expiration(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 65, int(exp))
+}
+
+func TestBasicPolicyMostConstrictiveSchedule(t *testing.T) {
+	policy := sealing.NewBasicPreCommitPolicy(&fakeChain{
+		h: abi.ChainEpoch(55),
+	}, 100)
+
+	pieces := []sealing.PieceWithOptionalDealInfo{
+		{
+			Piece: abi.PieceInfo{
+				Size:     abi.PaddedPieceSize(1024),
+				PieceCID: commcid.ReplicaCommitmentV1ToCID([]byte{1, 2, 3}),
+			},
+			DealInfo: &sealing.DealInfo{
+				DealID: abi.DealID(42),
+				DealSchedule: sealing.DealSchedule{
+					StartEpoch: abi.ChainEpoch(70),
+					EndEpoch:   abi.ChainEpoch(75),
+				},
+			},
+		},
+		{
+			Piece: abi.PieceInfo{
+				Size:     abi.PaddedPieceSize(1024),
+				PieceCID: commcid.ReplicaCommitmentV1ToCID([]byte{1, 2, 3}),
+			},
+			DealInfo: &sealing.DealInfo{
+				DealID: abi.DealID(43),
+				DealSchedule: sealing.DealSchedule{
+					StartEpoch: abi.ChainEpoch(80),
+					EndEpoch:   abi.ChainEpoch(100),
+				},
+			},
+		},
+	}
+
+	exp, err := policy.Expiration(context.Background(), pieces...)
+	require.NoError(t, err)
+
+	assert.Equal(t, 100, int(exp))
+}
+
+func TestBasicPolicyIgnoresExistingScheduleIfExpired(t *testing.T) {
+	policy := sealing.NewBasicPreCommitPolicy(&fakeChain{
+		h: abi.ChainEpoch(55),
+	}, 100)
+
+	pieces := []sealing.PieceWithOptionalDealInfo{
+		{
+			Piece: abi.PieceInfo{
+				Size:     abi.PaddedPieceSize(1024),
+				PieceCID: commcid.ReplicaCommitmentV1ToCID([]byte{1, 2, 3}),
+			},
+			DealInfo: &sealing.DealInfo{
+				DealID: abi.DealID(44),
+				DealSchedule: sealing.DealSchedule{
+					StartEpoch: abi.ChainEpoch(1),
+					EndEpoch:   abi.ChainEpoch(10),
+				},
+			},
+		},
+	}
+
+	exp, err := policy.Expiration(context.Background(), pieces...)
+	require.NoError(t, err)
+
+	assert.Equal(t, 155, int(exp))
+}
+
+func TestMissingDealIsIgnored(t *testing.T) {
+	policy := sealing.NewBasicPreCommitPolicy(&fakeChain{
+		h: abi.ChainEpoch(55),
+	}, 100)
+
+	pieces := []sealing.PieceWithOptionalDealInfo{
+		{
+			Piece: abi.PieceInfo{
+				Size:     abi.PaddedPieceSize(1024),
+				PieceCID: commcid.ReplicaCommitmentV1ToCID([]byte{1, 2, 3}),
+			},
+			DealInfo: &sealing.DealInfo{
+				DealID: abi.DealID(44),
+				DealSchedule: sealing.DealSchedule{
+					StartEpoch: abi.ChainEpoch(1),
+					EndEpoch:   abi.ChainEpoch(10),
+				},
+			},
+		},
+		{
+			Piece: abi.PieceInfo{
+				Size:     abi.PaddedPieceSize(1024),
+				PieceCID: commcid.ReplicaCommitmentV1ToCID([]byte{1, 2, 3}),
+			},
+			DealInfo: nil,
+		},
+	}
+
+	exp, err := policy.Expiration(context.Background(), pieces...)
+	require.NoError(t, err)
+
+	assert.Equal(t, 155, int(exp))
+}

--- a/precommit_policy_test.go
+++ b/precommit_policy_test.go
@@ -37,7 +37,7 @@ func TestBasicPolicyMostConstrictiveSchedule(t *testing.T) {
 		h: abi.ChainEpoch(55),
 	}, 100)
 
-	pieces := []sealing.PieceWithOptionalDealInfo{
+	pieces := []sealing.Piece{
 		{
 			Piece: abi.PieceInfo{
 				Size:     abi.PaddedPieceSize(1024),
@@ -77,7 +77,7 @@ func TestBasicPolicyIgnoresExistingScheduleIfExpired(t *testing.T) {
 		h: abi.ChainEpoch(55),
 	}, 100)
 
-	pieces := []sealing.PieceWithOptionalDealInfo{
+	pieces := []sealing.Piece{
 		{
 			Piece: abi.PieceInfo{
 				Size:     abi.PaddedPieceSize(1024),
@@ -104,7 +104,7 @@ func TestMissingDealIsIgnored(t *testing.T) {
 		h: abi.ChainEpoch(55),
 	}, 100)
 
-	pieces := []sealing.PieceWithOptionalDealInfo{
+	pieces := []sealing.Piece{
 		{
 			Piece: abi.PieceInfo{
 				Size:     abi.PaddedPieceSize(1024),

--- a/sealing.go
+++ b/sealing.go
@@ -35,7 +35,6 @@ type SealingAPI interface {
 	SendMsg(ctx context.Context, from, to address.Address, method abi.MethodNum, value, gasPrice big.Int, gasLimit int64, params []byte) (cid.Cid, error)
 	ChainHead(ctx context.Context) (TipSetToken, abi.ChainEpoch, error)
 	ChainGetRandomness(ctx context.Context, tok TipSetToken, personalization crypto.DomainSeparationTag, randEpoch abi.ChainEpoch, entropy []byte) (abi.Randomness, error)
-	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
 }
 
 type Sealing struct {

--- a/sealing.go
+++ b/sealing.go
@@ -49,9 +49,11 @@ type Sealing struct {
 	sc      SectorIDCounter
 	verif   ffiwrapper.Verifier
 	tktFn   TicketFn
+
+	pcp PreCommitPolicy
 }
 
-func New(api SealingAPI, events Events, maddr address.Address, worker address.Address, ds datastore.Batching, sealer sectorstorage.SectorManager, sc SectorIDCounter, verif ffiwrapper.Verifier, tktFn TicketFn) *Sealing {
+func New(api SealingAPI, events Events, maddr address.Address, worker address.Address, ds datastore.Batching, sealer sectorstorage.SectorManager, sc SectorIDCounter, verif ffiwrapper.Verifier, tktFn TicketFn, pcp PreCommitPolicy) *Sealing {
 	s := &Sealing{
 		api:    api,
 		events: events,
@@ -62,6 +64,7 @@ func New(api SealingAPI, events Events, maddr address.Address, worker address.Ad
 		sc:     sc,
 		verif:  verif,
 		tktFn:  tktFn,
+		pcp:    pcp,
 	}
 
 	s.sectors = statemachine.New(namespace.Wrap(ds, datastore.NewKey(SectorStorePrefix)), s, SectorInfo{})

--- a/states.go
+++ b/states.go
@@ -19,7 +19,7 @@ func (m *Sealing) handlePacking(ctx statemachine.Context, sector SectorInfo) err
 	log.Infow("performing filling up rest of the sector...", "sector", sector.SectorNumber)
 
 	var allocated abi.UnpaddedPieceSize
-	for _, piece := range sector.PiecesWithOptionalDealInfo {
+	for _, piece := range sector.Pieces {
 		allocated += piece.Piece.Size.Unpadded()
 	}
 
@@ -112,7 +112,7 @@ func (m *Sealing) handlePreCommitting(ctx statemachine.Context, sector SectorInf
 		}
 	}
 
-	expiration, err := m.pcp.Expiration(ctx.Context(), sector.PiecesWithOptionalDealInfo...)
+	expiration, err := m.pcp.Expiration(ctx.Context(), sector.Pieces...)
 	if err != nil {
 		return ctx.Send(SectorSealPreCommitFailed{xerrors.Errorf("handlePreCommitting: failed to compute pre-commit expiry: %w", err)})
 	}

--- a/states.go
+++ b/states.go
@@ -112,8 +112,13 @@ func (m *Sealing) handlePreCommitting(ctx statemachine.Context, sector SectorInf
 		}
 	}
 
+	expiration, err := m.pcp.Expiration(ctx.Context(), sector.PiecesWithOptionalDealInfo...)
+	if err != nil {
+		return ctx.Send(SectorSealPreCommitFailed{xerrors.Errorf("handlePreCommitting: failed to compute pre-commit expiry: %w", err)})
+	}
+
 	params := &miner.SectorPreCommitInfo{
-		Expiration:      10000000, // TODO: implement expiration
+		Expiration:      expiration,
 		SectorNumber:    sector.SectorNumber,
 		RegisteredProof: sector.SectorType,
 

--- a/types.go
+++ b/types.go
@@ -88,30 +88,27 @@ type SectorInfo struct {
 
 func (t *SectorInfo) pieceInfos() []abi.PieceInfo {
 	out := make([]abi.PieceInfo, len(t.Pieces))
-	for i, pdi := range t.Pieces {
-		out[i] = abi.PieceInfo{
-			Size:     pdi.Piece.Size,
-			PieceCID: pdi.Piece.PieceCID,
-		}
+	for i, p := range t.Pieces {
+		out[i] = p.Piece
 	}
 	return out
 }
 
 func (t *SectorInfo) dealIDs() []abi.DealID {
 	out := make([]abi.DealID, 0, len(t.Pieces))
-	for _, pdi := range t.Pieces {
-		if pdi.DealInfo == nil {
+	for _, p := range t.Pieces {
+		if p.DealInfo == nil {
 			continue
 		}
-		out = append(out, pdi.DealInfo.DealID)
+		out = append(out, p.DealInfo.DealID)
 	}
 	return out
 }
 
 func (t *SectorInfo) existingPieceSizes() []abi.UnpaddedPieceSize {
 	out := make([]abi.UnpaddedPieceSize, len(t.Pieces))
-	for i, pdi := range t.Pieces {
-		out[i] = pdi.Piece.Size.Unpadded()
+	for i, p := range t.Pieces {
+		out[i] = p.Piece.Size.Unpadded()
 	}
 	return out
 }

--- a/types.go
+++ b/types.go
@@ -11,16 +11,16 @@ import (
 	"github.com/filecoin-project/specs-storage/storage"
 )
 
-// PieceWithOptionalDealInfo is a tuple of piece and deal info
+// Piece is a tuple of piece and deal info
 type PieceWithDealInfo struct {
 	Piece    abi.PieceInfo
 	DealInfo DealInfo
 }
 
-// PieceWithOptionalDealInfo is a tuple of piece info and optional deal
-type PieceWithOptionalDealInfo struct {
+// Piece is a tuple of piece info and optional deal
+type Piece struct {
 	Piece    abi.PieceInfo
-	DealInfo *DealInfo // nil for pieces which do not yet appear in self-deals
+	DealInfo *DealInfo // nil for pieces which do not appear in deals (e.g. filler pieces)
 }
 
 // DealInfo is a tuple of deal identity and its schedule
@@ -55,7 +55,7 @@ type SectorInfo struct {
 	SectorType abi.RegisteredProof
 
 	// Packing
-	PiecesWithOptionalDealInfo []PieceWithOptionalDealInfo
+	Pieces []Piece
 
 	// PreCommit1
 	TicketValue   abi.SealRandomness
@@ -87,8 +87,8 @@ type SectorInfo struct {
 }
 
 func (t *SectorInfo) pieceInfos() []abi.PieceInfo {
-	out := make([]abi.PieceInfo, len(t.PiecesWithOptionalDealInfo))
-	for i, pdi := range t.PiecesWithOptionalDealInfo {
+	out := make([]abi.PieceInfo, len(t.Pieces))
+	for i, pdi := range t.Pieces {
 		out[i] = abi.PieceInfo{
 			Size:     pdi.Piece.Size,
 			PieceCID: pdi.Piece.PieceCID,
@@ -98,8 +98,8 @@ func (t *SectorInfo) pieceInfos() []abi.PieceInfo {
 }
 
 func (t *SectorInfo) dealIDs() []abi.DealID {
-	out := make([]abi.DealID, 0, len(t.PiecesWithOptionalDealInfo))
-	for _, pdi := range t.PiecesWithOptionalDealInfo {
+	out := make([]abi.DealID, 0, len(t.Pieces))
+	for _, pdi := range t.Pieces {
 		if pdi.DealInfo == nil {
 			continue
 		}
@@ -109,8 +109,8 @@ func (t *SectorInfo) dealIDs() []abi.DealID {
 }
 
 func (t *SectorInfo) existingPieceSizes() []abi.UnpaddedPieceSize {
-	out := make([]abi.UnpaddedPieceSize, len(t.PiecesWithOptionalDealInfo))
-	for i, pdi := range t.PiecesWithOptionalDealInfo {
+	out := make([]abi.UnpaddedPieceSize, len(t.Pieces))
+	for i, pdi := range t.Pieces {
 		out[i] = pdi.Piece.Size.Unpadded()
 	}
 	return out

--- a/types_test.go
+++ b/types_test.go
@@ -28,7 +28,7 @@ func TestSectorInfoSelialization(t *testing.T) {
 		State:        "stateful",
 		SectorNumber: 234,
 		Nonce:        345,
-		PiecesWithOptionalDealInfo: []PieceWithOptionalDealInfo{{
+		Pieces: []Piece{{
 			Piece: abi.PieceInfo{
 				Size:     5,
 				PieceCID: dummyCid,
@@ -62,7 +62,7 @@ func TestSectorInfoSelialization(t *testing.T) {
 	assert.Equal(t, si.Nonce, si2.Nonce)
 	assert.Equal(t, si.SectorNumber, si2.SectorNumber)
 
-	assert.Equal(t, si.PiecesWithOptionalDealInfo, si2.PiecesWithOptionalDealInfo)
+	assert.Equal(t, si.Pieces, si2.Pieces)
 	assert.Equal(t, si.CommD, si2.CommD)
 	assert.Equal(t, si.TicketValue, si2.TicketValue)
 	assert.Equal(t, si.TicketEpoch, si2.TicketEpoch)

--- a/types_test.go
+++ b/types_test.go
@@ -14,16 +14,26 @@ import (
 func TestSectorInfoSelialization(t *testing.T) {
 	d := abi.DealID(1234)
 
+	dealInfo := DealInfo{
+		DealID: d,
+		DealSchedule: DealSchedule{
+			StartEpoch: 0,
+			EndEpoch:   100,
+		},
+	}
+
 	dummyCid := builtin.AccountActorCodeID
 
 	si := &SectorInfo{
 		State:        "stateful",
 		SectorNumber: 234,
 		Nonce:        345,
-		Pieces: []Piece{{
-			DealID: &d,
-			Size:   5,
-			CommP:  dummyCid,
+		PiecesWithOptionalDealInfo: []PieceWithOptionalDealInfo{{
+			Piece: abi.PieceInfo{
+				Size:     5,
+				PieceCID: dummyCid,
+			},
+			DealInfo: &dealInfo,
 		}},
 		CommD:            &dummyCid,
 		CommR:            nil,
@@ -52,7 +62,7 @@ func TestSectorInfoSelialization(t *testing.T) {
 	assert.Equal(t, si.Nonce, si2.Nonce)
 	assert.Equal(t, si.SectorNumber, si2.SectorNumber)
 
-	assert.Equal(t, si.Pieces, si2.Pieces)
+	assert.Equal(t, si.PiecesWithOptionalDealInfo, si2.PiecesWithOptionalDealInfo)
 	assert.Equal(t, si.CommD, si2.CommD)
 	assert.Equal(t, si.TicketValue, si2.TicketValue)
 	assert.Equal(t, si.TicketEpoch, si2.TicketEpoch)


### PR DESCRIPTION
## What's in this PR?

This PR pulls in the sector pre-commit policy from go-storage-miner, which allows (you guessed it) the pre-commit policy to be selected by the node which controls the FSM's lifetime.