### PR TITLE
add a new state for precommit wait

### DIFF
--- a/fsm_events.go
+++ b/fsm_events.go
@@ -98,6 +98,14 @@ func (evt SectorPreCommit2) apply(state *SectorInfo) {
 	state.CommR = &commr
 }
 
+type SectorPreCommitLanded struct {
+	TipSet TipSetToken
+}
+
+func (evt SectorPreCommitLanded) apply(si *SectorInfo) {
+	si.PreCommitTipSet = evt.TipSet
+}
+
 type SectorSealPreCommitFailed struct{ error }
 
 func (evt SectorSealPreCommitFailed) FormatError(xerrors.Printer) (next error) { return evt.error }

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -41,6 +41,9 @@ func TestHappyPath(t *testing.T) {
 	require.Equal(m.t, m.state.State, PreCommitting)
 
 	m.planSingle(SectorPreCommitted{})
+	require.Equal(m.t, m.state.State, PreCommitWait)
+
+	m.planSingle(SectorPreCommitLanded{})
 	require.Equal(m.t, m.state.State, WaitSeed)
 
 	m.planSingle(SectorSeedReady{})
@@ -73,6 +76,9 @@ func TestSeedRevert(t *testing.T) {
 	require.Equal(m.t, m.state.State, PreCommitting)
 
 	m.planSingle(SectorPreCommitted{})
+	require.Equal(m.t, m.state.State, PreCommitWait)
+
+	m.planSingle(SectorPreCommitLanded{})
 	require.Equal(m.t, m.state.State, WaitSeed)
 
 	m.planSingle(SectorSeedReady{})

--- a/sector_state.go
+++ b/sector_state.go
@@ -11,6 +11,7 @@ const (
 	PreCommit1     SectorState = "PreCommit1"    // do PreCommit1
 	PreCommit2     SectorState = "PreCommit2"    // do PreCommit1
 	PreCommitting  SectorState = "PreCommitting" // on chain pre-commit
+	PreCommitWait  SectorState = "PreCommitWait" // waiting for precommit to land on chain
 	WaitSeed       SectorState = "WaitSeed"      // waiting for seed
 	Committing     SectorState = "Committing"
 	CommitWait     SectorState = "CommitWait" // waiting for message to land on chain

--- a/types.go
+++ b/types.go
@@ -67,6 +67,7 @@ type SectorInfo struct {
 	Proof []byte
 
 	PreCommitMessage *cid.Cid
+	PreCommitTipSet  TipSetToken
 
 	// WaitSeed
 	SeedValue abi.InteractiveSealRandomness


### PR DESCRIPTION
I don't think this actually makes anything better, yet. But it breaks out precommit and wait seed into two separate states, which should allow us to write some better error handling in the future.