### PR TITLE
checkCommit: handle missing precommits

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -29,6 +29,7 @@ type ErrPrecommitOnChain struct{ error }
 
 type ErrBadSeed struct{ error }
 type ErrInvalidProof struct{ error }
+type ErrNoPrecommit struct{ error }
 
 func checkPieces(ctx context.Context, si SectorInfo, api SealingAPI) error {
 	tok, height, err := api.ChainHead(ctx)
@@ -107,6 +108,10 @@ func (m *Sealing) checkCommit(ctx context.Context, si SectorInfo, proof []byte, 
 	pci, err := m.api.StateSectorPreCommitInfo(ctx, m.maddr, si.SectorNumber, tok)
 	if err != nil {
 		return xerrors.Errorf("getting precommit info: %w", err)
+	}
+
+	if pci == nil {
+		return &ErrNoPrecommit{xerrors.Errorf("precommit info not found on-chain")}
 	}
 
 	if pci.PreCommitEpoch+miner.PreCommitChallengeDelay != si.SeedEpoch {

--- a/fsm.go
+++ b/fsm.go
@@ -96,6 +96,7 @@ var fsmPlanners = map[SectorState]func(events []statemachine.Event, state *Secto
 		on(SectorRetryWaitSeed{}, WaitSeed),
 		on(SectorRetryComputeProof{}, Committing),
 		on(SectorRetryInvalidProof{}, Committing),
+		on(SectorRetryPreCommitWait{}, PreCommitWait),
 	),
 	FinalizeFailed: planOne(
 		on(SectorRetryFinalize{}, FinalizeSector),

--- a/fsm_events.go
+++ b/fsm_events.go
@@ -201,6 +201,10 @@ type SectorRetryWaitSeed struct{}
 
 func (evt SectorRetryWaitSeed) apply(state *SectorInfo) {}
 
+type SectorRetryPreCommitWait struct{}
+
+func (evt SectorRetryPreCommitWait) apply(state *SectorInfo) {}
+
 type SectorRetryComputeProof struct{}
 
 func (evt SectorRetryComputeProof) apply(state *SectorInfo) {

--- a/states.go
+++ b/states.go
@@ -214,9 +214,9 @@ func (m *Sealing) handleWaitSeed(ctx statemachine.Context, sector SectorInfo) er
 		}
 		rand, err := m.api.ChainGetRandomness(ectx, tok, crypto.DomainSeparationTag_InteractiveSealChallengeSeed, randHeight, buf.Bytes())
 		if err != nil {
-			err = xerrors.Errorf("failed to get randomness for computing seal proof: %w", err)
+			err = xerrors.Errorf("failed to get randomness for computing seal proof (ch %d; rh %d; tsk %x): %w", curH, randHeight, tok, err)
 
-			_ = ctx.Send(SectorFatalError{error: err})
+			_ = ctx.Send(SectorChainPreCommitFailed{error: err})
 			return err
 		}
 

--- a/states_failed.go
+++ b/states_failed.go
@@ -177,6 +177,9 @@ func (m *Sealing) handleCommitFailed(ctx statemachine.Context, sector SectorInfo
 			}
 
 			return ctx.Send(SectorRetryInvalidProof{})
+		case *ErrPrecommitOnChain:
+			log.Errorf("no precommit on chain, will retry: %+v", err)
+			return ctx.Send(SectorRetryPreCommitWait{})
 		default:
 			return xerrors.Errorf("checkCommit sanity check error: %w", err)
 		}


### PR DESCRIPTION
I'm not sure what unlikely chain of events leads sectors into this state, but the fix works on my miner

Fixes https://github.com/filecoin-project/lotus/issues/1968, https://github.com/filecoin-project/lotus/issues/1956