### PR TITLE
Handle missing on-chain precommit in WaitSeed

### DIFF
--- a/states.go
+++ b/states.go
@@ -208,6 +208,9 @@ func (m *Sealing) handleWaitSeed(ctx statemachine.Context, sector SectorInfo) er
 	if err != nil {
 		return xerrors.Errorf("getting precommit info: %w", err)
 	}
+	if pci == nil {
+		return ctx.Send(SectorChainPreCommitFailed{error: xerrors.Errorf("precommit info not found on chain")})
+	}
 
 	randHeight := pci.PreCommitEpoch + miner.PreCommitChallengeDelay
 


### PR DESCRIPTION
This apparently can/did happen (probably caused by a big reorg)