### PR TITLE
fix unhandled sector error: precommit info not found on-chain

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -29,7 +29,6 @@ type ErrPrecommitOnChain struct{ error }
 
 type ErrBadSeed struct{ error }
 type ErrInvalidProof struct{ error }
-type ErrNoPrecommit struct{ error }
 
 func checkPieces(ctx context.Context, si SectorInfo, api SealingAPI) error {
 	tok, height, err := api.ChainHead(ctx)
@@ -111,7 +110,7 @@ func (m *Sealing) checkCommit(ctx context.Context, si SectorInfo, proof []byte, 
 	}
 
 	if pci == nil {
-		return &ErrNoPrecommit{xerrors.Errorf("precommit info not found on-chain")}
+		return &ErrPrecommitOnChain{xerrors.Errorf("precommit info not found on-chain")}
 	}
 
 	if pci.PreCommitEpoch+miner.PreCommitChallengeDelay != si.SeedEpoch {


### PR DESCRIPTION
When the state machine runs to the `handleCommitFailed -> checkCommit`, if no Precommit information is found on chain, `ErrNoPrecommit` will be returned in `checkCommit`. However, when checked outside, it is the `case *ErrPrecommitOnChain`. If it cannot match correctly, it will enter the default branch, causing the state machine to stop, and the sector state will stay at the `CommitFailed`.